### PR TITLE
Result href decode

### DIFF
--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -139,17 +139,16 @@ public class TransformServiceXsl implements TransformService {
 		addToPatchset(patchset, outputPath.append(baseItemId.getRelPath().getName()), baseStreamProvider, overwrite, props);
 		
 		Set<String> resultDocsHrefs = outputURIResolver.getResultDocumentHrefs();
-		for (String relpath: resultDocsHrefs) {
-			if (relpath.startsWith("/")) {
-				throw new IllegalArgumentException("Relative href must not start with slash: " + relpath);
+		for (String href: resultDocsHrefs) {
+			if (href.startsWith("/")) {
+				throw new IllegalArgumentException("Relative href must not start with slash: " + href);
 			}
 			
-			relpath = decodeHref(relpath); // TODO: What happens if the href do contain a char that should not be decoded? Like a space in the filename or a %.  
-			
-			XmlSourceDocumentS9api resultDocument = outputURIResolver.getResultDocument(relpath);
+			XmlSourceDocumentS9api resultDocument = outputURIResolver.getResultDocument(href);
 			TransformStreamProvider streamProvider = transformerOutput.getTransformStreamProvider(resultDocument, null);
 			
-			CmsItemPath path = outputPath.append(Arrays.asList(relpath.split("/")));
+			String decodedHref = decodeHref(href); // Items will be commited with decoded hrefs.
+			CmsItemPath path = outputPath.append(Arrays.asList(decodedHref.split("/")));
 			addToPatchset(patchset, path, streamProvider, overwrite, props);
 		}
 		

--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -334,7 +334,7 @@ public class TransformServiceXsl implements TransformService {
 			href = java.net.URLDecoder.decode(href, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			e.printStackTrace();
-			throw new IllegalArgumentException("Could not decode file name: " + href);
+			throw new IllegalArgumentException("Could not decode URL: " + href);
 		}
 		return href;
 	}

--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -142,6 +143,8 @@ public class TransformServiceXsl implements TransformService {
 			if (relpath.startsWith("/")) {
 				throw new IllegalArgumentException("Relative href must not start with slash: " + relpath);
 			}
+			
+			relpath = decodeHref(relpath);
 			
 			XmlSourceDocumentS9api resultDocument = outputURIResolver.getResultDocument(relpath);
 			TransformStreamProvider streamProvider = transformerOutput.getTransformStreamProvider(resultDocument, null);
@@ -324,6 +327,16 @@ public class TransformServiceXsl implements TransformService {
 			patchset.add(new FolderExist(parentPath));
 
 		}
+	}
+	
+	private String decodeHref(String href) {
+		try {
+			href = java.net.URLDecoder.decode(href, "UTF-8");
+		} catch (UnsupportedEncodingException e) {
+			e.printStackTrace();
+			throw new IllegalArgumentException("Could not decode file name: " + href);
+		}
+		return href;
 	}
 	
 	private class EmptyStreamException extends Exception {

--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -333,7 +333,7 @@ public class TransformServiceXsl implements TransformService {
 		try {
 			href = java.net.URLDecoder.decode(href, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
-			logger.error("Could not decode URL: {}", href);
+			logger.error("Could not decode URL", e);
 			throw new IllegalArgumentException("Could not decode URL: " + href);
 		}
 		return href;

--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -144,7 +144,7 @@ public class TransformServiceXsl implements TransformService {
 				throw new IllegalArgumentException("Relative href must not start with slash: " + relpath);
 			}
 			
-			relpath = decodeHref(relpath);
+			relpath = decodeHref(relpath); // TODO: What happens if the href do contain a char that should not be decoded? Like a space in the filename or a %.  
 			
 			XmlSourceDocumentS9api resultDocument = outputURIResolver.getResultDocument(relpath);
 			TransformStreamProvider streamProvider = transformerOutput.getTransformStreamProvider(resultDocument, null);

--- a/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
+++ b/src/main/java/se/simonsoft/cms/transform/service/TransformServiceXsl.java
@@ -333,7 +333,7 @@ public class TransformServiceXsl implements TransformService {
 		try {
 			href = java.net.URLDecoder.decode(href, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
+			logger.error("Could not decode URL: {}", href);
 			throw new IllegalArgumentException("Could not decode URL: " + href);
 		}
 		return href;

--- a/src/test/java/se/simonsoft/cms/transform/service/TransformServiceXslTest.java
+++ b/src/test/java/se/simonsoft/cms/transform/service/TransformServiceXslTest.java
@@ -433,8 +433,40 @@ public class TransformServiceXslTest {
 		String sec2Str = baos2.toString(StandardCharsets.UTF_8.name());
 		assertTrue(sec2Str.contains("multiple-output=\"true\""));
 		assertTrue(sec2Str.contains("name=\"section2.xml\""));
-		
+	}
+	
+	@Test
+	public void testOutputWithEncodedHref() throws Exception {
+		CmsItemId itemId = new CmsItemIdArg(transformTestDoc);
+		CmsItem item = lookup.getItem(itemId);
 
+		TransformConfig config = new TransformConfig();
+		config.setActive(true);
+
+		TransformConfigOptions configOptions = new TransformConfigOptions();
+		configOptions.setType("xsl");
+
+		Map<String, String> optionsParams = new HashMap<String, String>();
+		optionsParams.put("stylesheet", "/stylesheet/transform-multiple-output.xsl");
+		optionsParams.put("output", "/transformed/multiple/existing");
+		optionsParams.put("overwrite", "true");
+		optionsParams.put("comment", "Automatic transform!");
+		configOptions.setParams(optionsParams);
+
+		config.setOptions(configOptions);
+
+		transformService.transform(item, config);
+		
+		String outputPath = optionsParams.get("output");
+		
+		// section3.xml path should have been url decoded (ö should be ö, the space should have been preserved and %20 should be decoded to space).
+		CmsItemId sec3Id = new CmsItemIdArg(repo, new CmsItemPath(outputPath.concat("/sections/földer space/folder encoded/section3.xml")));
+		CmsItem sec3Item = lookup.getItem(sec3Id.withPegRev(2L));
+		ByteArrayOutputStream baos3 = new ByteArrayOutputStream();
+		sec3Item.getContents(baos3);
+		String sec3Str = baos3.toString(StandardCharsets.UTF_8.name());
+		assertTrue(sec3Str.contains("multiple-output=\"true\""));
+		assertTrue(sec3Str.contains("name=\"földer space/folder%20encoded/section3.xml\""));
 	}
 
 	@Test

--- a/src/test/java/se/simonsoft/cms/transform/service/TransformServiceXslTest.java
+++ b/src/test/java/se/simonsoft/cms/transform/service/TransformServiceXslTest.java
@@ -460,6 +460,7 @@ public class TransformServiceXslTest {
 		String outputPath = optionsParams.get("output");
 		
 		// section3.xml path should have been url decoded (ö should be ö, the space should have been preserved and %20 should be decoded to space).
+		// It is technically incorrect to send non-encoded string to result-document href. 
 		CmsItemId sec3Id = new CmsItemIdArg(repo, new CmsItemPath(outputPath.concat("/sections/földer space/folder encoded/section3.xml")));
 		CmsItem sec3Item = lookup.getItem(sec3Id.withPegRev(2L));
 		ByteArrayOutputStream baos3 = new ByteArrayOutputStream();

--- a/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/doc/transform-test.xml
+++ b/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/doc/transform-test.xml
@@ -32,5 +32,9 @@ xml:lang="en-GB">
 			<title>Second chapter</title>
 			<p>The end is nigh.</p>
 		</section>
+		<section name="földer space/folder%20encoded/section3.xml">
+			<title>Third chapter</title>
+			<p>The end is nigh.</p>
+		</section>
 	</body>
 </document><?Pub Caret -2?>

--- a/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/repository.xml
+++ b/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/repository.xml
@@ -156,6 +156,16 @@
 			</properties>
 		</entry>
 		<entry kind="file">
+			<name>transformed/multiple/existing/section3.xml</name>
+			<size>181</size>
+			<commit revision="1">
+				<author>m</author>
+				<date>2013-01-04T14:33:14.600772Z</date>
+			</commit>
+			<properties>
+			</properties>
+		</entry>
+		<entry kind="file">
 			<name>stylesheet/transform-single-output.xsl</name>
 			<size>1170</size>
 			<commit revision="1">

--- a/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/transformed/multiple/existing/section3.xml
+++ b/src/test/resources/se/simonsoft/cms/transform/datasets/repo1/transformed/multiple/existing/section3.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2009-2017 Simonsoft Nordic AB
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<section name="section3.xml">
+	<title multiple-output="true">Third chapter</title>
+	<p multiple-output="true">The end is nigh.</p>
+</section>


### PR DESCRIPTION
Tried a href with a space in the filename. `sections/s ection2.xml` the outURIresolver will give us `sections/s%20ection2.xml` will be docoded to `sections/s ection2.xml`.
With a % in the filename the decoder will throw a IAE(Illegal hex chars in escape (%) pattern)